### PR TITLE
Correct mention of test cases in diagnose error md

### DIFF
--- a/app/vscode/asset/walkthrough/diagnose-errors.md
+++ b/app/vscode/asset/walkthrough/diagnose-errors.md
@@ -4,6 +4,6 @@
 2. Invoke the "Diagnose Errors" command using one of the following options:
    1. Run the `Rubberduck: Diagnose Errors 💬` command from the command palette.
    1. Select the `Diagnose Errors 💬` entry in the editor context menu (right-click).
-3. The test case shows up in a new editor tab. You can refine it in the conversation panel.
+3. A potential solution will be shown in the chat window. You can refine it in the conversation panel.
 
 ![Diagnose Errors](https://raw.githubusercontent.com/rubberduck-ai/rubberduck-vscode/main/app/vscode/asset/media/screenshot-diagnose-errors.png)


### PR DESCRIPTION
Diagnose Error mark down mentioned test cases instead of the error solution in the chat window