### PR TITLE
Automate deployments + deploy to OVSX

### DIFF
--- a/.github/workflows/ovsx-deploy.yml
+++ b/.github/workflows/ovsx-deploy.yml
@@ -1,0 +1,31 @@
+name: Open VSX Deploy
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 7
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build & deploy to Open VSX
+        run: pnpm deploy:ovsx -p ${{ secrets.OVSX_ACCESS_TOKEN }}
+        env:
+          NODE_OPTIONS: "--max_old_space_size=8192"

--- a/.github/workflows/vscode-deploy.yml
+++ b/.github/workflows/vscode-deploy.yml
@@ -1,0 +1,32 @@
+name: VSCode Deploy
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 7
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build & deploy to VS Code
+        run: pnpm deploy:vscode
+        env:
+          NODE_OPTIONS: "--max_old_space_size=8192"
+          VSCE_PAT: ${{ secrets.VSCODE_ACCESS_TOKEN }}

--- a/app/vscode/project.json
+++ b/app/vscode/project.json
@@ -8,6 +8,22 @@
         "cwd": "app/vscode",
         "command": "bin/package.sh"
       }
+    },
+    "publish-vscode": {
+      "dependsOn": ["package"],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "app/vscode",
+        "command": "vsce publish"
+      }
+    },
+    "publish-ovsx": {
+      "dependsOn": ["package"],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "app/vscode",
+        "command": "ovsx publish"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "prepare": "husky install",
     "test": "pnpm nx run extension:test",
-    "test-watch": "pnpm nx run extension:test-watch"
+    "test-watch": "pnpm nx run extension:test-watch",
+    "deploy:vscode": "vsce publish"
   },
   "private": true,
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "prepare": "husky install",
     "test": "pnpm nx run extension:test",
     "test-watch": "pnpm nx run extension:test-watch",
-    "deploy:vscode": "vsce publish",
-    "deploy:ovsx": "ovsx publish"
+    "deploy:vscode": "pnpm nx run vscode:publish-vscode",
+    "deploy:ovsx": "pnpm nx run vscode:publish-ovsx"
   },
   "private": true,
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "prepare": "husky install",
     "test": "pnpm nx run extension:test",
     "test-watch": "pnpm nx run extension:test-watch",
-    "deploy:vscode": "vsce publish"
+    "deploy:vscode": "vsce publish",
+    "deploy:ovsx": "ovsx publish"
   },
   "private": true,
   "devDependencies": {
@@ -20,6 +21,7 @@
     "husky": "^8.0.0",
     "lint-staged": "13.1.0",
     "nx": "15.4.1",
+    "ovsx": "0.8.0",
     "prettier": "2.8.3",
     "typescript": "4.9.4",
     "vitest": "0.28.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ importers:
       husky: ^8.0.0
       lint-staged: 13.1.0
       nx: 15.4.1
+      ovsx: 0.8.0
       prettier: 2.8.3
       typescript: 4.9.4
       vitest: 0.28.3
@@ -28,6 +29,7 @@ importers:
       husky: 8.0.3
       lint-staged: 13.1.0
       nx: 15.4.1
+      ovsx: 0.8.0
       prettier: 2.8.3
       typescript: 4.9.4
       vitest: 0.28.3
@@ -1003,6 +1005,10 @@ packages:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
     dev: true
     optional: true
+
+  /ci-info/2.0.0:
+    resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
+    dev: true
 
   /classnames/2.3.2:
     resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}
@@ -2025,6 +2031,13 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /is-ci/2.0.0:
+    resolution: {integrity: sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==}
+    hasBin: true
+    dependencies:
+      ci-info: 2.0.0
+    dev: true
+
   /is-core-module/2.11.0:
     resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
     dependencies:
@@ -2879,6 +2892,21 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.3
+    dev: true
+
+  /ovsx/0.8.0:
+    resolution: {integrity: sha512-W1U7lgBIbhSB1DcqyGKeenKzmwWYY78SkWd+BUKKyLyqN6w39Uekdr0PKAM7dyBGb0JLtLE7d86A1jJVn8bEng==}
+    engines: {node: '>= 14'}
+    hasBin: true
+    dependencies:
+      '@vscode/vsce': 2.16.0
+      commander: 6.2.1
+      follow-redirects: 1.15.2
+      is-ci: 2.0.0
+      leven: 3.1.0
+      tmp: 0.2.1
+    transitivePeerDependencies:
+      - debug
     dev: true
 
   /p-limit/3.1.0:


### PR DESCRIPTION
Related to #3 

This should trigger automatic deployments to both VS Code & OVSX marketplaces whenever there is a new GitHub release. Thus, deploying a new version only becomes a matter of creating a new release here: https://github.com/rubberduck-ai/rubberduck-vscode/releases/new

Pre-requisite:
- [x] @lgrammel needs to configure the `VSCODE_ACCESS_TOKEN` secret on GitHub (the PAT you use to deploy to VS Code today… or create a new one)
- [x] @lgrammel needs to configure the `OVSX_ACCESS_TOKEN` secret on GitHub too, which you can create here: https://open-vsx.org/user-settings/tokens

I _think_ the deployments should work, but I'm a bit blind. I will monitor the subsequent releases and fix whatever doesn't work with the workflows.