### PR TITLE
Better error messages

### DIFF
--- a/lib/common/src/webview-api/ConversationSchema.ts
+++ b/lib/common/src/webview-api/ConversationSchema.ts
@@ -1,4 +1,5 @@
 import zod from "zod";
+import { errorSchema } from "./ErrorSchema";
 
 export const selectionSchema = zod.object({
   filename: zod.string(),
@@ -19,6 +20,7 @@ export type Message = zod.infer<typeof messageSchema>;
 const messageExchangeContentSchema = zod.object({
   type: zod.literal("messageExchange"),
   messages: zod.array(messageSchema),
+  error: errorSchema.optional(),
   state: zod.discriminatedUnion("type", [
     zod.object({
       type: zod.literal("userCanReply"),
@@ -32,10 +34,6 @@ const messageExchangeContentSchema = zod.object({
       type: zod.literal("botAnswerStreaming"),
       partialAnswer: zod.string(),
     }),
-    zod.object({
-      type: zod.literal("error"),
-      errorMessage: zod.string(),
-    }),
   ]),
 });
 
@@ -46,6 +44,7 @@ export type MessageExchangeContent = zod.infer<
 const instructionRefinementContentSchema = zod.object({
   type: zod.literal("instructionRefinement"),
   instruction: zod.string(),
+  error: errorSchema.optional(),
   state: zod.discriminatedUnion("type", [
     zod.object({
       type: zod.literal("userCanRefineInstruction"),
@@ -55,10 +54,6 @@ const instructionRefinementContentSchema = zod.object({
     zod.object({
       type: zod.literal("waitingForBotAnswer"),
       botAction: zod.union([zod.string(), zod.undefined()]),
-    }),
-    zod.object({
-      type: zod.literal("error"),
-      errorMessage: zod.string(),
     }),
   ]),
 });

--- a/lib/common/src/webview-api/ErrorSchema.ts
+++ b/lib/common/src/webview-api/ErrorSchema.ts
@@ -5,7 +5,10 @@ export const errorSchema = zod.union([
   zod.object({
     title: zod.string(),
     message: zod.string(),
-    level: zod.union([zod.literal("error"), zod.literal("warning")]).optional(),
+    level: zod
+      .union([zod.literal("error"), zod.literal("warning")])
+      .default("error")
+      .optional(),
     disableRetry: zod.boolean().optional(),
     disableDismiss: zod.boolean().optional(),
   }),
@@ -16,7 +19,7 @@ export const errorSchema = zod.union([
  * Provide re-assurance and explain why it happened. Suggest actions
  * to help them fix it and/or give them a way out.
  *
- * You can use Markdown syntax.
+ * You can use Markdown syntax for `title` and `message`.
  *
  * @see https://wix-ux.com/when-life-gives-you-lemons-write-better-error-messages-46c5223e1a2f
  *

--- a/lib/common/src/webview-api/ErrorSchema.ts
+++ b/lib/common/src/webview-api/ErrorSchema.ts
@@ -1,17 +1,20 @@
 import zod from "zod";
 
-export const errorSchema = zod.object({
-  title: zod.string(),
-  message: zod.string(),
-  retry: zod
-    .function()
-    .returns(zod.union([zod.void(), zod.promise(zod.void())]))
-    .optional(),
-  dismiss: zod
-    .function()
-    .returns(zod.union([zod.void(), zod.promise(zod.void())]))
-    .optional(),
-});
+export const errorSchema = zod.union([
+  zod.string(),
+  zod.object({
+    title: zod.string(),
+    message: zod.string(),
+    retry: zod
+      .function()
+      .returns(zod.union([zod.void(), zod.promise(zod.void())]))
+      .optional(),
+    dismiss: zod
+      .function()
+      .returns(zod.union([zod.void(), zod.promise(zod.void())]))
+      .optional(),
+  }),
+]);
 
 /**
  * Say what happened.
@@ -20,7 +23,10 @@ export const errorSchema = zod.object({
  *
  * You can use Markdown syntax.
  *
- * @example
+ * @example Simple scenario
+ * "Unable to connect to OpenAI"
+ *
+ * @example More elaborate object
  * {
  *   title: "Unable to connect to OpenAI",
  *   message: "Your changes were saved, but we could not connect your account due to a technical issue on our end. Please try connecting again. If the issue keeps happening, [contact Support](#link-to-contact-support)."

--- a/lib/common/src/webview-api/ErrorSchema.ts
+++ b/lib/common/src/webview-api/ErrorSchema.ts
@@ -5,14 +5,9 @@ export const errorSchema = zod.union([
   zod.object({
     title: zod.string(),
     message: zod.string(),
-    retry: zod
-      .function()
-      .returns(zod.union([zod.void(), zod.promise(zod.void())]))
-      .optional(),
-    dismiss: zod
-      .function()
-      .returns(zod.union([zod.void(), zod.promise(zod.void())]))
-      .optional(),
+    level: zod.union([zod.literal("error"), zod.literal("warning")]).optional(),
+    disableRetry: zod.boolean().optional(),
+    disableDismiss: zod.boolean().optional(),
   }),
 ]);
 

--- a/lib/common/src/webview-api/ErrorSchema.ts
+++ b/lib/common/src/webview-api/ErrorSchema.ts
@@ -1,0 +1,29 @@
+import zod from "zod";
+
+export const errorSchema = zod.object({
+  title: zod.string(),
+  message: zod.string(),
+  retry: zod
+    .function()
+    .returns(zod.union([zod.void(), zod.promise(zod.void())]))
+    .optional(),
+  dismiss: zod
+    .function()
+    .returns(zod.union([zod.void(), zod.promise(zod.void())]))
+    .optional(),
+});
+
+/**
+ * Say what happened.
+ * Provide re-assurance and explain why it happened. Suggest actions
+ * to help them fix it and/or give them a way out.
+ *
+ * You can use Markdown syntax.
+ *
+ * @example
+ * {
+ *   title: "Unable to connect to OpenAI",
+ *   message: "Your changes were saved, but we could not connect your account due to a technical issue on our end. Please try connecting again. If the issue keeps happening, [contact Support](#link-to-contact-support)."
+ * }
+ */
+export type Error = zod.infer<typeof errorSchema>;

--- a/lib/common/src/webview-api/ErrorSchema.ts
+++ b/lib/common/src/webview-api/ErrorSchema.ts
@@ -18,6 +18,8 @@ export const errorSchema = zod.union([
  *
  * You can use Markdown syntax.
  *
+ * @see https://wix-ux.com/when-life-gives-you-lemons-write-better-error-messages-46c5223e1a2f
+ *
  * @example Simple scenario
  * "Unable to connect to OpenAI"
  *

--- a/lib/common/src/webview-api/OutgoingMessage.ts
+++ b/lib/common/src/webview-api/OutgoingMessage.ts
@@ -28,7 +28,7 @@ export const outgoingMessageSchema = zod.discriminatedUnion("type", [
     }),
   }),
   zod.object({
-    type: zod.literal("showError"),
+    type: zod.literal("reportError"),
     error: errorSchema,
   }),
   zod.object({

--- a/lib/common/src/webview-api/OutgoingMessage.ts
+++ b/lib/common/src/webview-api/OutgoingMessage.ts
@@ -1,4 +1,5 @@
 import zod from "zod";
+import { errorSchema } from "./ErrorSchema";
 
 export const outgoingMessageSchema = zod.discriminatedUnion("type", [
   zod.object({
@@ -25,6 +26,10 @@ export const outgoingMessageSchema = zod.discriminatedUnion("type", [
       id: zod.string(),
       message: zod.string(),
     }),
+  }),
+  zod.object({
+    type: zod.literal("showError"),
+    error: errorSchema,
   }),
   zod.object({
     type: zod.literal("retry"),

--- a/lib/common/src/webview-api/OutgoingMessage.ts
+++ b/lib/common/src/webview-api/OutgoingMessage.ts
@@ -32,6 +32,12 @@ export const outgoingMessageSchema = zod.discriminatedUnion("type", [
     error: errorSchema,
   }),
   zod.object({
+    type: zod.literal("dismissError"),
+    data: zod.object({
+      id: zod.string(),
+    }),
+  }),
+  zod.object({
     type: zod.literal("retry"),
     data: zod.object({
       id: zod.string(),

--- a/lib/common/src/webview-api/PanelState.ts
+++ b/lib/common/src/webview-api/PanelState.ts
@@ -1,5 +1,6 @@
 import zod from "zod";
 import { conversationSchema } from "./ConversationSchema";
+import { errorSchema } from "./ErrorSchema";
 
 export const panelStateSchema = zod
   .discriminatedUnion("type", [
@@ -8,6 +9,7 @@ export const panelStateSchema = zod
       conversations: zod.array(conversationSchema),
       selectedConversationId: zod.union([zod.string(), zod.undefined()]),
       hasOpenAIApiKey: zod.boolean(),
+      error: errorSchema.optional(),
     }),
     zod.object({
       type: zod.literal("diff"),

--- a/lib/common/src/webview-api/index.ts
+++ b/lib/common/src/webview-api/index.ts
@@ -1,4 +1,5 @@
 export * from "./ConversationSchema";
+export * from "./ErrorSchema";
 export * from "./IncomingMessage";
 export * from "./OutgoingMessage";
 export * from "./PanelState";

--- a/lib/extension/src/chat/ChatController.ts
+++ b/lib/extension/src/chat/ChatController.ts
@@ -103,11 +103,10 @@ export class ChatController {
           .getConversationById(message.data.id)
           ?.dismissError();
         break;
-      case "applyDiff": {
-        break;
-      }
+      case "applyDiff":
       case "reportError": {
-        await this.reportError(message.error);
+        // Architecture debt: there are 2 views, but 1 outgoing message type
+        // These are handled in the Conversation
         break;
       }
       default: {
@@ -161,13 +160,5 @@ export class ChatController {
       console.log(error);
       await vscode.window.showErrorMessage(error?.message ?? error);
     }
-  }
-
-  private async reportError(error: webviewApi.Error) {
-    const conversation = this.chatModel.getSelectedConversation();
-    if (!conversation) return;
-
-    await this.showChatPanel();
-    conversation.setError(error);
   }
 }

--- a/lib/extension/src/chat/ChatController.ts
+++ b/lib/extension/src/chat/ChatController.ts
@@ -98,6 +98,11 @@ export class ChatController {
         await this.chatModel.getConversationById(message.data.id)?.retry();
         break;
       }
+      case "dismissError":
+        await this.chatModel
+          .getConversationById(message.data.id)
+          ?.dismissError();
+        break;
       case "applyDiff": {
         break;
       }

--- a/lib/extension/src/chat/ChatController.ts
+++ b/lib/extension/src/chat/ChatController.ts
@@ -106,8 +106,8 @@ export class ChatController {
       case "applyDiff": {
         break;
       }
-      case "showError": {
-        await this.showError(message.error);
+      case "reportError": {
+        await this.reportError(message.error);
         break;
       }
       default: {
@@ -163,7 +163,7 @@ export class ChatController {
     }
   }
 
-  private async showError(error: webviewApi.Error) {
+  private async reportError(error: webviewApi.Error) {
     const conversation = this.chatModel.getSelectedConversation();
     if (!conversation) return;
 

--- a/lib/extension/src/chat/ChatController.ts
+++ b/lib/extension/src/chat/ChatController.ts
@@ -102,6 +102,7 @@ export class ChatController {
         break;
       }
       case "showError": {
+        await this.showError(message.error);
         break;
       }
       default: {
@@ -155,5 +156,10 @@ export class ChatController {
       console.log(error);
       await vscode.window.showErrorMessage(error?.message ?? error);
     }
+  }
+
+  private async showError(error: webviewApi.Error) {
+    console.error(error.message);
+    await this.showChatPanel();
   }
 }

--- a/lib/extension/src/chat/ChatController.ts
+++ b/lib/extension/src/chat/ChatController.ts
@@ -101,6 +101,9 @@ export class ChatController {
       case "applyDiff": {
         break;
       }
+      case "showError": {
+        break;
+      }
       default: {
         const exhaustiveCheck: never = type;
         throw new Error(`unsupported type: ${exhaustiveCheck}`);

--- a/lib/extension/src/chat/ChatController.ts
+++ b/lib/extension/src/chat/ChatController.ts
@@ -159,7 +159,10 @@ export class ChatController {
   }
 
   private async showError(error: webviewApi.Error) {
-    console.error(error.message);
+    const conversation = this.chatModel.getSelectedConversation();
+    if (!conversation) return;
+
     await this.showChatPanel();
+    conversation.setError(error);
   }
 }

--- a/lib/extension/src/chat/ChatModel.ts
+++ b/lib/extension/src/chat/ChatModel.ts
@@ -13,6 +13,11 @@ export class ChatModel {
     return this.conversations.find((conversation) => conversation.id === id);
   }
 
+  getSelectedConversation(): Conversation | undefined {
+    if (!this.selectedConversationId) return;
+    return this.getConversationById(this.selectedConversationId);
+  }
+
   deleteConversation(id: string) {
     this.conversations = this.conversations.filter(
       (conversation) => conversation.id !== id

--- a/lib/extension/src/chat/ChatModel.ts
+++ b/lib/extension/src/chat/ChatModel.ts
@@ -13,11 +13,6 @@ export class ChatModel {
     return this.conversations.find((conversation) => conversation.id === id);
   }
 
-  getSelectedConversation(): Conversation | undefined {
-    if (!this.selectedConversationId) return;
-    return this.getConversationById(this.selectedConversationId);
-  }
-
   deleteConversation(id: string) {
     this.conversations = this.conversations.filter(
       (conversation) => conversation.id !== id

--- a/lib/extension/src/conversation/Conversation.ts
+++ b/lib/extension/src/conversation/Conversation.ts
@@ -460,7 +460,7 @@ export class Conversation {
     await this.updateChatPanel();
   }
 
-  async setError(error: webviewApi.Error) {
+  private async setError(error: webviewApi.Error) {
     this.error = error;
     await this.updateChatPanel();
   }

--- a/lib/extension/src/conversation/Conversation.ts
+++ b/lib/extension/src/conversation/Conversation.ts
@@ -418,7 +418,7 @@ export class Conversation {
 
   async retry() {
     this.state = { type: "waitingForBotAnswer" };
-    await this.updateChatPanel();
+    await this.dismissError();
 
     await this.executeChat();
   }
@@ -462,6 +462,11 @@ export class Conversation {
 
   async setError(error: webviewApi.Error) {
     this.error = error;
+    await this.updateChatPanel();
+  }
+
+  async dismissError() {
+    this.error = undefined;
     await this.updateChatPanel();
   }
 

--- a/lib/extension/src/conversation/Conversation.ts
+++ b/lib/extension/src/conversation/Conversation.ts
@@ -373,7 +373,7 @@ export class Conversation {
     this.diffEditor.onDidReceiveMessage(async (rawMessage) => {
       const message = webviewApi.outgoingMessageSchema.parse(rawMessage);
 
-      if (message.type === "showError") {
+      if (message.type === "reportError") {
         this.setError(message.error);
         return;
       }

--- a/lib/extension/src/conversation/Conversation.ts
+++ b/lib/extension/src/conversation/Conversation.ts
@@ -22,6 +22,7 @@ export class Conversation {
   readonly id: string;
   protected readonly openAIClient: OpenAIClient;
   protected state: webviewApi.MessageExchangeContent["state"];
+  protected error: webviewApi.Error | undefined;
   protected readonly messages: webviewApi.Message[];
   protected readonly updateChatPanel: () => Promise<void>;
 
@@ -164,16 +165,14 @@ export class Conversation {
       });
 
       if (completion.type === "error") {
-        await this.setErrorStatus({ errorMessage: completion.errorMessage });
+        await this.setError(completion.errorMessage);
         return;
       }
 
       await this.handleCompletion(completion.content, prompt);
     } catch (error: any) {
       console.log(error);
-      await this.setErrorStatus({
-        errorMessage: error?.message ?? "Unknown error",
-      });
+      await this.setError(error?.message ?? "Unknown error");
     }
   }
 
@@ -373,6 +372,12 @@ export class Conversation {
 
     this.diffEditor.onDidReceiveMessage(async (rawMessage) => {
       const message = webviewApi.outgoingMessageSchema.parse(rawMessage);
+
+      if (message.type === "showError") {
+        this.setError(message.error);
+        return;
+      }
+
       if (message.type !== "applyDiff") {
         return;
       }
@@ -455,8 +460,8 @@ export class Conversation {
     await this.updateChatPanel();
   }
 
-  protected async setErrorStatus({ errorMessage }: { errorMessage: string }) {
-    this.state = { type: "error", errorMessage };
+  async setError(error: webviewApi.Error) {
+    this.error = error;
     await this.updateChatPanel();
   }
 
@@ -478,11 +483,13 @@ export class Conversation {
                 ? this.messages.slice(1)
                 : this.messages,
               state: this.state,
+              error: this.error,
             }
           : {
               type: "instructionRefinement",
               instruction: "", // TODO last user message?
               state: this.refinementInstructionState(),
+              error: this.error,
             },
     };
   }
@@ -495,9 +502,6 @@ export class Conversation {
         return {
           type: "waitingForBotAnswer",
         };
-
-      case "error":
-        return this.state;
 
       case "userCanReply":
         return {

--- a/lib/webview/asset/chat.css
+++ b/lib/webview/asset/chat.css
@@ -284,9 +284,14 @@ button.error-retry {
 .level-warning button.error-retry {
   background: var(--vscode-inputValidation-warningBorder);
 }
-button.error-retry:hover,
-button.error-dismiss:hover {
+button.error-dismiss {
+  background: var(--vscode-button-secondaryBackground);
+}
+button.error-retry:hover {
   opacity: 70%;
+}
+button.error-dismiss:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
 }
 
 span.error-retry:hover {

--- a/lib/webview/asset/chat.css
+++ b/lib/webview/asset/chat.css
@@ -229,20 +229,67 @@ body {
 }
 
 .message.error {
+  margin: 0;
+  padding: var(--rubberduck-container-padding);
+  border: 1px solid;
+  border-color: var(--vscode-errorForeground);
   color: var(--vscode-errorForeground);
+}
+
+.message.error.level-warning {
+  border-color: var(--vscode-editorWarning-foreground);
+  color: var(--vscode-editorWarning-foreground);
+}
+
+.error-body {
   display: flex;
   justify-content: space-between;
 }
 
-.message.error > .error-retry {
-  cursor: pointer;
+.error-body > .error-retry {
   display: flex;
+  text-align: left;
   margin-top: auto;
   margin-bottom: auto;
   margin-left: 10px;
 }
 
-.message.error > .error-retry:hover {
+.error-title {
+  display: block;
+  padding-bottom: var(--rubberduck-container-padding);
+  font-size: 110%;
+  text-decoration: underline;
+}
+
+.error-buttons {
+  display: flex;
+  gap: var(--rubberduck-container-padding);
+}
+
+.error-retry,
+.error-dismiss {
+  display: block;
+  cursor: pointer;
+  text-align: center;
+  margin-top: var(--rubberduck-container-padding);
+}
+
+button.error-retry,
+button.error-dismiss {
+  margin-bottom: 0;
+}
+button.error-retry {
+  background: var(--vscode-inputValidation-errorBorder);
+}
+.level-warning button.error-retry {
+  background: var(--vscode-inputValidation-warningBorder);
+}
+button.error-retry:hover,
+button.error-dismiss:hover {
+  opacity: 70%;
+}
+
+span.error-retry:hover {
   filter: brightness(125%);
   cursor: pointer;
 }

--- a/lib/webview/asset/chat.css
+++ b/lib/webview/asset/chat.css
@@ -8,6 +8,7 @@ body {
 
 .codicon.inline {
   vertical-align: sub;
+  margin-right: 5px;
 }
 
 .start-chat,

--- a/lib/webview/src/component/DiffView.tsx
+++ b/lib/webview/src/component/DiffView.tsx
@@ -320,7 +320,7 @@ function toPrismHighlightOptions(
 
     default:
       sendMessage({
-        type: "showError",
+        type: "reportError",
         error: {
           title: `Unable to highlight syntax for language ${languageId}`,
           message: `We could not find a matching Prism grammar for language ${languageId}. We used the default one (${DEFAULT_PRISM_OPTIONS.language}). Please [open an issue](https://github.com/rubberduck-ai/rubberduck-vscode/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=Add%20syntax%20highlight%20for%20language%20%22${languageId}%22) to ask for supporting this language.`,

--- a/lib/webview/src/component/DiffView.tsx
+++ b/lib/webview/src/component/DiffView.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import DiffViewer, { DiffMethod } from "react-diff-viewer-continued";
+import { sendMessage } from "../vscode/SendMessage";
 
 // @ts-expect-error Somehow the component can only be accessed from .default
 const ReactDiffViewer = DiffViewer.default;
@@ -318,9 +319,13 @@ function toPrismHighlightOptions(
       return DEFAULT_PRISM_OPTIONS;
 
     default:
-      console.warn(
-        `Can't find Prism grammar for language ${languageId}, use default one`
-      );
+      sendMessage({
+        type: "showError",
+        error: {
+          title: `Unable to highlight syntax for language ${languageId}`,
+          message: `We could not find a matching Prism grammar for language ${languageId}. We used the default one (${DEFAULT_PRISM_OPTIONS.language}). Please [open an issue](https://github.com/rubberduck-ai/rubberduck-vscode/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=Add%20syntax%20highlight%20for%20language%20%22${languageId}%22) to ask for supporting this language.`,
+        },
+      });
       return DEFAULT_PRISM_OPTIONS;
   }
 }

--- a/lib/webview/src/component/DiffView.tsx
+++ b/lib/webview/src/component/DiffView.tsx
@@ -324,6 +324,8 @@ function toPrismHighlightOptions(
         error: {
           title: `Unable to highlight syntax for language ${languageId}`,
           message: `We could not find a matching Prism grammar for language ${languageId}. We used the default one (${DEFAULT_PRISM_OPTIONS.language}). Please [open an issue](https://github.com/rubberduck-ai/rubberduck-vscode/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=Add%20syntax%20highlight%20for%20language%20%22${languageId}%22) to ask for supporting this language.`,
+          level: "warning",
+          disableRetry: true,
         },
       });
       return DEFAULT_PRISM_OPTIONS;

--- a/lib/webview/src/component/ErrorMessage.tsx
+++ b/lib/webview/src/component/ErrorMessage.tsx
@@ -16,7 +16,7 @@ export function ErrorMessage({
       <span className="error-message">Error: {error}</span>
       <span className="error-retry" onClick={onClickRetry}>
         <i className="codicon codicon-debug-restart inline" />
-        <span style={{ marginLeft: "5px" }}>Retry</span>
+        <span>Retry</span>
       </span>
     </div>
   ) : (
@@ -36,7 +36,7 @@ export function ErrorMessage({
         {!error.disableRetry && (
           <button className="error-retry" onClick={onClickRetry}>
             <i className="codicon codicon-debug-restart inline" />
-            <span style={{ marginLeft: "5px" }}>Retry</span>
+            <span>Retry</span>
           </button>
         )}
       </div>

--- a/lib/webview/src/component/ErrorMessage.tsx
+++ b/lib/webview/src/component/ErrorMessage.tsx
@@ -1,0 +1,22 @@
+import { webviewApi } from "@rubberduck/common";
+import React from "react";
+
+export function ErrorMessage({
+  error,
+  onClickRetry,
+}: {
+  error: webviewApi.Error;
+  onClickRetry: () => void;
+}) {
+  return (
+    <div key={"error"} className={"message bot error"}>
+      <span className={"error-message"}>
+        Error: {typeof error === "string" ? error : error.title}
+      </span>
+      <span className={"error-retry"} onClick={onClickRetry}>
+        <i className="codicon codicon-debug-restart inline" />
+        <span style={{ marginLeft: "5px" }}>Retry</span>
+      </span>
+    </div>
+  );
+}

--- a/lib/webview/src/component/ErrorMessage.tsx
+++ b/lib/webview/src/component/ErrorMessage.tsx
@@ -4,9 +4,11 @@ import ReactMarkdown from "react-markdown";
 
 export function ErrorMessage({
   error,
+  onClickDismiss,
   onClickRetry,
 }: {
   error: webviewApi.Error;
+  onClickDismiss: () => void;
   onClickRetry: () => void;
 }) {
   return typeof error === "string" ? (
@@ -27,8 +29,8 @@ export function ErrorMessage({
       </span>
       <div className="error-buttons">
         {!error.disableDismiss && (
-          <button className="error-dismiss" onClick={onClickRetry}>
-            <span style={{ marginLeft: "5px" }}>Dismiss</span>
+          <button className="error-dismiss" onClick={onClickDismiss}>
+            Dismiss
           </button>
         )}
         {!error.disableRetry && (

--- a/lib/webview/src/component/ErrorMessage.tsx
+++ b/lib/webview/src/component/ErrorMessage.tsx
@@ -1,5 +1,6 @@
 import { webviewApi } from "@rubberduck/common";
 import React from "react";
+import ReactMarkdown from "react-markdown";
 
 export function ErrorMessage({
   error,
@@ -8,15 +9,35 @@ export function ErrorMessage({
   error: webviewApi.Error;
   onClickRetry: () => void;
 }) {
-  return (
-    <div key={"error"} className={"message bot error"}>
-      <span className={"error-message"}>
-        Error: {typeof error === "string" ? error : error.title}
-      </span>
-      <span className={"error-retry"} onClick={onClickRetry}>
+  return typeof error === "string" ? (
+    <div key="error" className="message bot error error-body">
+      <span className="error-message">Error: {error}</span>
+      <span className="error-retry" onClick={onClickRetry}>
         <i className="codicon codicon-debug-restart inline" />
         <span style={{ marginLeft: "5px" }}>Retry</span>
       </span>
+    </div>
+  ) : (
+    <div key="error" className={`message bot error level-${error.level}`}>
+      <span className="error-title">
+        <ReactMarkdown>{error.title}</ReactMarkdown>
+      </span>
+      <span className="error-message">
+        <ReactMarkdown>{error.message}</ReactMarkdown>
+      </span>
+      <div className="error-buttons">
+        {!error.disableDismiss && (
+          <button className="error-dismiss" onClick={onClickRetry}>
+            <span style={{ marginLeft: "5px" }}>Dismiss</span>
+          </button>
+        )}
+        {!error.disableRetry && (
+          <button className="error-retry" onClick={onClickRetry}>
+            <i className="codicon codicon-debug-restart inline" />
+            <span style={{ marginLeft: "5px" }}>Retry</span>
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/lib/webview/src/component/ExpandedConversationView.tsx
+++ b/lib/webview/src/component/ExpandedConversationView.tsx
@@ -7,9 +7,16 @@ import { MessageExchangeView } from "./MessageExchangeView";
 export const ExpandedConversationView: React.FC<{
   conversation: webviewApi.Conversation;
   onSendMessage: (message: string) => void;
+  onClickDismiss: () => void;
   onClickRetry: () => void;
   onClickDelete: () => void;
-}> = ({ conversation, onSendMessage, onClickRetry, onClickDelete }) => {
+}> = ({
+  conversation,
+  onSendMessage,
+  onClickDismiss,
+  onClickRetry,
+  onClickDelete,
+}) => {
   const content = conversation.content;
 
   return (
@@ -23,8 +30,9 @@ export const ExpandedConversationView: React.FC<{
             return (
               <MessageExchangeView
                 content={content}
-                onClickRetry={onClickRetry}
                 onSendMessage={onSendMessage}
+                onClickDismiss={onClickDismiss}
+                onClickRetry={onClickRetry}
               />
             );
           case "instructionRefinement":
@@ -32,6 +40,7 @@ export const ExpandedConversationView: React.FC<{
               <InstructionRefinementView
                 content={content}
                 onSendMessage={onSendMessage}
+                onClickDismiss={onClickDismiss}
                 onClickRetry={onClickRetry}
               />
             );

--- a/lib/webview/src/component/InstructionRefinementView.tsx
+++ b/lib/webview/src/component/InstructionRefinementView.tsx
@@ -41,24 +41,27 @@ export function InstructionRefinementView({
                 </button>
               </>
             );
-          case "error":
-            return (
-              <div key={"error"} className={"message bot error"}>
-                <span className={"error-message"}>
-                  Error: {content.state.errorMessage}
-                </span>
-                <span className={"error-retry"} onClick={onClickRetry}>
-                  <i className="codicon codicon-debug-restart inline" />
-                  <span style={{ marginLeft: "5px" }}>Retry</span>
-                </span>
-              </div>
-            );
           default: {
             const exhaustiveCheck: never = type;
             throw new Error(`unsupported type: ${exhaustiveCheck}`);
           }
         }
       })()}
+
+      {content.error && (
+        <div key={"error"} className={"message bot error"}>
+          <span className={"error-message"}>
+            Error:{" "}
+            {typeof content.error === "string"
+              ? content.error
+              : content.error.title}
+          </span>
+          <span className={"error-retry"} onClick={onClickRetry}>
+            <i className="codicon codicon-debug-restart inline" />
+            <span style={{ marginLeft: "5px" }}>Retry</span>
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/webview/src/component/InstructionRefinementView.tsx
+++ b/lib/webview/src/component/InstructionRefinementView.tsx
@@ -6,10 +6,12 @@ import { ErrorMessage } from "./ErrorMessage";
 export function InstructionRefinementView({
   content,
   onSendMessage,
+  onClickDismiss,
   onClickRetry,
 }: {
   content: webviewApi.InstructionRefinementContent;
   onSendMessage: (message: string) => void;
+  onClickDismiss: () => void;
   onClickRetry: () => void;
 }) {
   const [inputText, setInputText] = useState(content.instruction);
@@ -50,7 +52,11 @@ export function InstructionRefinementView({
       })()}
 
       {content.error && (
-        <ErrorMessage error={content.error} onClickRetry={onClickRetry} />
+        <ErrorMessage
+          error={content.error}
+          onClickDismiss={onClickDismiss}
+          onClickRetry={onClickRetry}
+        />
       )}
     </div>
   );

--- a/lib/webview/src/component/InstructionRefinementView.tsx
+++ b/lib/webview/src/component/InstructionRefinementView.tsx
@@ -1,6 +1,7 @@
 import { webviewApi } from "@rubberduck/common";
 import React, { useState } from "react";
 import { ChatInput } from "./ChatInput";
+import { ErrorMessage } from "./ErrorMessage";
 
 export function InstructionRefinementView({
   content,
@@ -49,18 +50,7 @@ export function InstructionRefinementView({
       })()}
 
       {content.error && (
-        <div key={"error"} className={"message bot error"}>
-          <span className={"error-message"}>
-            Error:{" "}
-            {typeof content.error === "string"
-              ? content.error
-              : content.error.title}
-          </span>
-          <span className={"error-retry"} onClick={onClickRetry}>
-            <i className="codicon codicon-debug-restart inline" />
-            <span style={{ marginLeft: "5px" }}>Retry</span>
-          </span>
-        </div>
+        <ErrorMessage error={content.error} onClickRetry={onClickRetry} />
       )}
     </div>
   );

--- a/lib/webview/src/component/MessageExchangeView.tsx
+++ b/lib/webview/src/component/MessageExchangeView.tsx
@@ -2,6 +2,7 @@ import { webviewApi } from "@rubberduck/common";
 import React, { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { ChatInput } from "./ChatInput";
+import { ErrorMessage } from "./ErrorMessage";
 
 export function MessageExchangeView({
   content,
@@ -68,18 +69,7 @@ export function MessageExchangeView({
       })()}
 
       {content.error && (
-        <div key={"error"} className={"message bot error"}>
-          <span className={"error-message"}>
-            Error:{" "}
-            {typeof content.error === "string"
-              ? content.error
-              : content.error.title}
-          </span>
-          <span className={"error-retry"} onClick={onClickRetry}>
-            <i className="codicon codicon-debug-restart inline" />
-            <span style={{ marginLeft: "5px" }}>Retry</span>
-          </span>
-        </div>
+        <ErrorMessage error={content.error} onClickRetry={onClickRetry} />
       )}
     </div>
   );

--- a/lib/webview/src/component/MessageExchangeView.tsx
+++ b/lib/webview/src/component/MessageExchangeView.tsx
@@ -6,11 +6,13 @@ import { ErrorMessage } from "./ErrorMessage";
 
 export function MessageExchangeView({
   content,
+  onClickDismiss,
   onClickRetry,
   onSendMessage,
 }: {
   content: webviewApi.MessageExchangeContent;
   onSendMessage: (message: string) => void;
+  onClickDismiss: () => void;
   onClickRetry: () => void;
 }) {
   const [inputText, setInputText] = useState("");
@@ -69,7 +71,11 @@ export function MessageExchangeView({
       })()}
 
       {content.error && (
-        <ErrorMessage error={content.error} onClickRetry={onClickRetry} />
+        <ErrorMessage
+          error={content.error}
+          onClickDismiss={onClickDismiss}
+          onClickRetry={onClickRetry}
+        />
       )}
     </div>
   );

--- a/lib/webview/src/component/MessageExchangeView.tsx
+++ b/lib/webview/src/component/MessageExchangeView.tsx
@@ -60,24 +60,27 @@ export function MessageExchangeView({
                 }}
               />
             );
-          case "error":
-            return (
-              <div key={"error"} className={"message bot error"}>
-                <span className={"error-message"}>
-                  Error: {content.state.errorMessage}
-                </span>
-                <span className={"error-retry"} onClick={onClickRetry}>
-                  <i className="codicon codicon-debug-restart inline" />
-                  <span style={{ marginLeft: "5px" }}>Retry</span>
-                </span>
-              </div>
-            );
           default: {
             const exhaustiveCheck: never = type;
             throw new Error(`unsupported type: ${exhaustiveCheck}`);
           }
         }
       })()}
+
+      {content.error && (
+        <div key={"error"} className={"message bot error"}>
+          <span className={"error-message"}>
+            Error:{" "}
+            {typeof content.error === "string"
+              ? content.error
+              : content.error.title}
+          </span>
+          <span className={"error-retry"} onClick={onClickRetry}>
+            <i className="codicon codicon-debug-restart inline" />
+            <span style={{ marginLeft: "5px" }}>Retry</span>
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/webview/src/panel/ChatPanelView.tsx
+++ b/lib/webview/src/panel/ChatPanelView.tsx
@@ -70,6 +70,12 @@ export const ChatPanelView: React.FC<{
                 data: { id: conversation.id },
               })
             }
+            onClickDismiss={() =>
+              sendMessage({
+                type: "dismissError",
+                data: { id: conversation.id },
+              })
+            }
             onClickDelete={() =>
               sendMessage({
                 type: "deleteConversation",


### PR DESCRIPTION
Closes #41 

The main change is that "error" isn't a state anymore, but an optional attribute of a Conversation. That way, we can show the error at the bottom of the conversation instead of replacing the whole thing (after a few experimentations, it felt to be the best alternative)

| Simple Error | Detailed Error |
|---|---|
| ![simpler error](https://user-images.githubusercontent.com/1094774/218929824-9dfce318-4d1f-41af-8891-41480c9967f0.png) | ![error](https://user-images.githubusercontent.com/1094774/218929820-246a3e87-513f-400e-b551-6676da4d5510.png) |

The "Dismiss" button clears the error. For detailed errors, it's possible to disable the Dismiss button, the Retry button, or both. The layout will adapt.

![no retry](https://user-images.githubusercontent.com/1094774/218929822-a0d2e0a6-4194-45e4-9ee6-6266b6de2969.png)

I also made it possible for detailed errors to be "warnings". It makes more sense when you want to report something to the user, but there is no need to retry. For instance:

![warning level](https://user-images.githubusercontent.com/1094774/218929825-4bea2340-e281-463a-b905-300a1253e7a3.png)

But I still don't have a strong opinion on this. Feel free to iterate on that. 
Same story for the design: I went for something that looks better, but is not too fancy. Feel free to make updates.

Other things:
- Detailed errors support Markdown in title & message
- Errors can be triggered from any conversation… but there is no "top-level" error yet. 

I have only ported the "syntax highlight" error so far. But with the system in place, we will be able to port more!