### PR TITLE
Add button to export conversation into Markdown

### DIFF
--- a/lib/common/src/webview-api/OutgoingMessage.ts
+++ b/lib/common/src/webview-api/OutgoingMessage.ts
@@ -21,6 +21,12 @@ export const outgoingMessageSchema = zod.discriminatedUnion("type", [
     }),
   }),
   zod.object({
+    type: zod.literal("exportConversation"),
+    data: zod.object({
+      id: zod.string(),
+    }),
+  }),
+  zod.object({
     type: zod.literal("sendMessage"),
     data: zod.object({
       id: zod.string(),

--- a/lib/extension/src/chat/ChatController.ts
+++ b/lib/extension/src/chat/ChatController.ts
@@ -94,6 +94,12 @@ export class ChatController {
         await this.updateChatPanel();
         break;
       }
+      case "exportConversation": {
+        await this.chatModel
+          .getConversationById(message.data.id)
+          ?.exportMarkdown();
+        break;
+      }
       case "retry": {
         await this.chatModel.getConversationById(message.data.id)?.retry();
         break;

--- a/lib/extension/src/conversation/Conversation.ts
+++ b/lib/extension/src/conversation/Conversation.ts
@@ -105,6 +105,23 @@ export class Conversation {
     return this.template.header.icon.value;
   }
 
+  async exportMarkdown(): Promise<void> {
+    const document = await vscode.workspace.openTextDocument({
+      language: "markdown",
+      content: this.getMarkdownExport(),
+    });
+    await vscode.window.showTextDocument(document);
+  }
+
+  private getMarkdownExport(): string {
+    return this.messages
+      .flatMap(({ author, content }) => [
+        author === "bot" ? "# Answer" : "# Question",
+        content,
+      ])
+      .join("\n\n");
+  }
+
   private async resolveVariablesAtMessageTime() {
     return resolveVariables(this.template.variables, {
       time: "message",

--- a/lib/webview/asset/chat.css
+++ b/lib/webview/asset/chat.css
@@ -299,11 +299,13 @@ span.error-retry:hover {
   cursor: pointer;
 }
 
-.action-delete {
+.action-delete,
+.action-export {
   cursor: pointer;
 }
 
-.action-delete:hover {
+.action-delete:hover,
+.action-export:hover {
   color: var(--vscode-charts-red);
 }
 

--- a/lib/webview/asset/chat.css
+++ b/lib/webview/asset/chat.css
@@ -302,10 +302,17 @@ span.error-retry:hover {
 .action-delete,
 .action-export {
   cursor: pointer;
+  border-radius: 5px;
+  padding: 3px;
 }
 
 .action-delete:hover,
 .action-export:hover {
+  color: var(--vscode-icon-foreground);
+  background-color: var(--vscode-sideBar-background);
+}
+
+.action-delete:hover {
   color: var(--vscode-charts-red);
 }
 

--- a/lib/webview/src/component/ExpandedConversationView.tsx
+++ b/lib/webview/src/component/ExpandedConversationView.tsx
@@ -10,12 +10,14 @@ export const ExpandedConversationView: React.FC<{
   onClickDismiss: () => void;
   onClickRetry: () => void;
   onClickDelete: () => void;
+  onClickExport: () => void;
 }> = ({
   conversation,
   onSendMessage,
   onClickDismiss,
   onClickRetry,
   onClickDelete,
+  onClickExport,
 }) => {
   const content = conversation.content;
 
@@ -53,6 +55,10 @@ export const ExpandedConversationView: React.FC<{
 
       <div className="footer">
         <span className="action-panel">
+          <i
+            className="codicon codicon-markdown inline action-export"
+            onClick={onClickExport}
+          />
           <i
             className="codicon codicon-trash inline action-delete"
             onClick={onClickDelete}

--- a/lib/webview/src/component/ExpandedConversationView.tsx
+++ b/lib/webview/src/component/ExpandedConversationView.tsx
@@ -56,11 +56,13 @@ export const ExpandedConversationView: React.FC<{
       <div className="footer">
         <span className="action-panel">
           <i
-            className="codicon codicon-markdown inline action-export"
+            className="codicon codicon-save inline action-export"
+            title="Export conversation"
             onClick={onClickExport}
           />
           <i
             className="codicon codicon-trash inline action-delete"
+            title="Delete conversation"
             onClick={onClickDelete}
           />
         </span>

--- a/lib/webview/src/panel/ChatPanelView.tsx
+++ b/lib/webview/src/panel/ChatPanelView.tsx
@@ -82,6 +82,12 @@ export const ChatPanelView: React.FC<{
                 data: { id: conversation.id },
               })
             }
+            onClickExport={() => {
+              sendMessage({
+                type: "exportConversation",
+                data: { id: conversation.id },
+              });
+            }}
           />
         ) : (
           <CollapsedConversationView


### PR DESCRIPTION
This adds a button to each conversation that will export the whole conversation into Markdown format. User prompts are marked as `# Question` and bot answers are marked as `# Answer`.

Since the bot answers are already using Markdown syntax, we already get the proper formatting for free.

I decided to make it create a new document that can be saved. I think it makes it easier for the user to decide if they want to save it or not, and where to put it, how to name it, etc.

Closes #48

https://user-images.githubusercontent.com/1094774/220237710-41f2c7cc-c937-4ac8-a37f-5b242fd5399e.mp4

