### PR TITLE
Make OpenAI URL configurable

### DIFF
--- a/app/vscode/asset/package.json
+++ b/app/vscode/asset/package.json
@@ -169,6 +169,12 @@
           ],
           "markdownDescription": "Specify the verbosity of logs that will appear in 'Rubberduck: Show Logs'.",
           "scope": "application"
+        },
+        "rubberduck.openAI.baseUrl": {
+          "type": "string",
+          "default": "https://api.openai.com/v1/",
+          "markdownDescription": "Specify the URL to the OpenAI API. If you are using a proxy, you can set it here.",
+          "scope": "application"
         }
       }
     },

--- a/lib/extension/src/extension.ts
+++ b/lib/extension/src/extension.ts
@@ -7,7 +7,7 @@ import { DiffEditorManager } from "./diff/DiffEditorManager";
 import { indexRepository } from "./index/indexRepository";
 import { getVSCodeLogLevel, LoggerUsingVSCodeOutput } from "./logger";
 import { ApiKeyManager } from "./openai/ApiKeyManager";
-import { OpenAIClient } from "./openai/OpenAIClient";
+import { getVSCodeOpenAIBaseUrl, OpenAIClient } from "./openai/OpenAIClient";
 
 export const activate = async (context: vscode.ExtensionContext) => {
   const apiKeyManager = new ApiKeyManager({
@@ -46,6 +46,13 @@ export const activate = async (context: vscode.ExtensionContext) => {
   const openAIClient = new OpenAIClient({
     apiKeyManager,
     logger: vscodeLogger,
+    openAIBaseUrl: getVSCodeOpenAIBaseUrl(),
+  });
+
+  vscode.workspace.onDidChangeConfiguration((event) => {
+    if (event.affectsConfiguration("rubberduck.openAI.baseUrl")) {
+      openAIClient.setOpenAIBaseUrl(getVSCodeOpenAIBaseUrl());
+    }
   });
 
   const chatController = new ChatController({

--- a/lib/extension/src/openai/OpenAIClient.ts
+++ b/lib/extension/src/openai/OpenAIClient.ts
@@ -227,7 +227,7 @@ export class OpenAIClient {
           content: completion,
         };
       } else {
-        this.logger.debug(["Not streaming response)", "Parse the response"]);
+        this.logger.debug(["Not streaming response", "Parse the response"]);
         const completion = completionSchema.parse(response.data).choices[0]
           ?.text;
 


### PR DESCRIPTION
Close #39 

![OpenAI base URL](https://user-images.githubusercontent.com/1094774/223203007-9f9e4baa-e28c-447c-a39f-5557f04edac4.png)

It defaults to the current value. Changing it will affect further calls.

You can see that in the logs:

![logs](https://user-images.githubusercontent.com/1094774/223203037-0d62b246-8245-4965-828f-239a45c4045a.png)

The only gotcha is that nothing prevents you from using an API that won't be compatible, but I think it's expected. The logs will tell something is wrong anyway.
