### PR TITLE
Attempt to better secure line-selection logic

### DIFF
--- a/lib/extension/src/conversation/input/getSelectionWithDiagnostics.ts
+++ b/lib/extension/src/conversation/input/getSelectionWithDiagnostics.ts
@@ -15,9 +15,10 @@ export const getSelectedTextWithDiagnostics = async ({
   const document = activeEditor.document;
   const selection = activeEditor.selection;
 
+  // expand range to beginning and end of line, because ranges tend to be inaccurate
   const range = new vscode.Range(
-    new vscode.Position(selection.start.line, selection.start.character),
-    new vscode.Position(selection.end.line, selection.end.character)
+    new vscode.Position(selection.start.line, 0),
+    new vscode.Position(selection.end.line + 1, 0)
   );
 
   const includedDiagnosticSeverities = diagnosticSeverities.map(
@@ -83,8 +84,8 @@ function annotateSelectionWithDiagnostics({
   selectionStartLine: number;
   diagnostics: Array<DiagnosticInRange>;
 }) {
-  const lines = selectionText.split(/[\r\n]+/);
-  return lines
+  return selectionText
+    .split("\n")
     .map((line, index) => {
       const actualLineNumber = selectionStartLine + index;
       const lineDiagnostics = diagnostics.filter(
@@ -93,14 +94,15 @@ function annotateSelectionWithDiagnostics({
 
       return lineDiagnostics.length === 0
         ? line
-        : `${line}\n${lineDiagnostics
-            .map(
-              (diagnostic) =>
-                `${getLabel(diagnostic.severity)} ${diagnostic.source}${
-                  diagnostic.code
-                }: ${diagnostic.message}`
-            )
-            .join("\n")}`;
+        : `${line}
+${lineDiagnostics
+  .map(
+    (diagnostic) =>
+      `${getLabel(diagnostic.severity)} ${diagnostic.source}${
+        diagnostic.code
+      }: ${diagnostic.message}`
+  )
+  .join("\n")}`;
     })
     .join("\n");
 }

--- a/lib/extension/src/conversation/input/getSelectionWithDiagnostics.ts
+++ b/lib/extension/src/conversation/input/getSelectionWithDiagnostics.ts
@@ -12,13 +12,13 @@ export const getSelectedTextWithDiagnostics = async ({
     return undefined;
   }
 
-  const document = activeEditor.document;
-  const selection = activeEditor.selection;
+  // P42 said this could be destructured
+  const { document, selection } = activeEditor;
 
-  // expand range to beginning and end of line, because ranges tend to be inaccurate
+  // Ensure range is acurrately mapping the selected lines, start to end
   const range = new vscode.Range(
     new vscode.Position(selection.start.line, 0),
-    new vscode.Position(selection.end.line + 1, 0)
+    new vscode.Position(selection.end.line, selection.end.character)
   );
 
   const includedDiagnosticSeverities = diagnosticSeverities.map(
@@ -85,7 +85,7 @@ function annotateSelectionWithDiagnostics({
   diagnostics: Array<DiagnosticInRange>;
 }) {
   return selectionText
-    .split("\n")
+    .split(/[\r\n]+/)
     .map((line, index) => {
       const actualLineNumber = selectionStartLine + index;
       const lineDiagnostics = diagnostics.filter(

--- a/lib/extension/src/conversation/input/getSelectionWithDiagnostics.ts
+++ b/lib/extension/src/conversation/input/getSelectionWithDiagnostics.ts
@@ -15,10 +15,9 @@ export const getSelectedTextWithDiagnostics = async ({
   const document = activeEditor.document;
   const selection = activeEditor.selection;
 
-  // expand range to beginning and end of line, because ranges tend to be inaccurate
   const range = new vscode.Range(
-    new vscode.Position(selection.start.line, 0),
-    new vscode.Position(selection.end.line + 1, 0)
+    new vscode.Position(selection.start.line, selection.start.character),
+    new vscode.Position(selection.end.line, selection.end.character)
   );
 
   const includedDiagnosticSeverities = diagnosticSeverities.map(
@@ -84,8 +83,8 @@ function annotateSelectionWithDiagnostics({
   selectionStartLine: number;
   diagnostics: Array<DiagnosticInRange>;
 }) {
-  return selectionText
-    .split("\n")
+  const lines = selectionText.split(/[\r\n]+/);
+  return lines
     .map((line, index) => {
       const actualLineNumber = selectionStartLine + index;
       const lineDiagnostics = diagnostics.filter(
@@ -94,15 +93,14 @@ function annotateSelectionWithDiagnostics({
 
       return lineDiagnostics.length === 0
         ? line
-        : `${line}
-${lineDiagnostics
-  .map(
-    (diagnostic) =>
-      `${getLabel(diagnostic.severity)} ${diagnostic.source}${
-        diagnostic.code
-      }: ${diagnostic.message}`
-  )
-  .join("\n")}`;
+        : `${line}\n${lineDiagnostics
+            .map(
+              (diagnostic) =>
+                `${getLabel(diagnostic.severity)} ${diagnostic.source}${
+                  diagnostic.code
+                }: ${diagnostic.message}`
+            )
+            .join("\n")}`;
     })
     .join("\n");
 }

--- a/lib/extension/src/conversation/input/getSelectionWithDiagnostics.ts
+++ b/lib/extension/src/conversation/input/getSelectionWithDiagnostics.ts
@@ -12,7 +12,6 @@ export const getSelectedTextWithDiagnostics = async ({
     return undefined;
   }
 
-  // P42 said this could be destructured
   const { document, selection } = activeEditor;
 
   // Ensure range is acurrately mapping the selected lines, start to end
@@ -96,13 +95,12 @@ function annotateSelectionWithDiagnostics({
         ? line
         : `${line}
 ${lineDiagnostics
-  .map(
-    (diagnostic) =>
-      `${getLabel(diagnostic.severity)} ${diagnostic.source}${
-        diagnostic.code
-      }: ${diagnostic.message}`
-  )
-  .join("\n")}`;
+          .map(
+            (diagnostic) =>
+              `${getLabel(diagnostic.severity)} ${diagnostic.source}${diagnostic.code
+              }: ${diagnostic.message}`
+          )
+          .join("\n")}`;
     })
     .join("\n");
 }

--- a/lib/webview/project.json
+++ b/lib/webview/project.json
@@ -14,7 +14,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "lib/webview",
-        "command": "npx esbuild build/webview.js --external:vscode '--define:process.env.NODE_ENV=\"production\"' --bundle --platform=browser --outfile=dist/webview.js"
+        "command": "npx esbuild build/webview.js --external:vscode \"--define:process.env.NODE_ENV=\"production\"\" --bundle --platform=browser --outfile=dist/webview.js"
       }
     }
   }


### PR DESCRIPTION
Previously, the selected range for code was coming up with a single-line offset. This fix attempts to ensure the correct selection of lines is loaded, and checked against both kinds of new-line characters. At the present, the given range may still show as 1 more starting line; the reasons for this are unknown at this time.