### PR TITLE
Add all open workspace files as context for request

### DIFF
--- a/app/vscode/asset/package.json
+++ b/app/vscode/asset/package.json
@@ -221,7 +221,7 @@
         },
         "rubberduck.model": {
           "type": "string",
-          "default": "gpt-3.5-turbo",
+          "default": "gpt-3.5-turbo-16k",
           "enum": [
             "gpt-3.5-turbo",
             "gpt-3.5-turbo-16k",

--- a/lib/extension/src/conversation/ConversationTypesProvider.ts
+++ b/lib/extension/src/conversation/ConversationTypesProvider.ts
@@ -59,7 +59,6 @@ export class ConversationTypesProvider {
     const result = await loadConversationFromFile(fileUri);
 
     if (result.type === "error") {
-      debugger;
       throw new Error(
         `Failed to load chat template '${fileUri.toString()}': ${result.error}`
       );

--- a/lib/extension/src/conversation/ConversationTypesProvider.ts
+++ b/lib/extension/src/conversation/ConversationTypesProvider.ts
@@ -42,6 +42,7 @@ export class ConversationTypesProvider {
       await this.loadBuiltinTemplate("task", "document-code.rdt.md"),
       await this.loadBuiltinTemplate("task", "edit-code.rdt.md"),
       await this.loadBuiltinTemplate("task", "explain-code.rdt.md"),
+      await this.loadBuiltinTemplate("task", "explain-code-w-context.rdt.md"),
       await this.loadBuiltinTemplate("task", "find-bugs.rdt.md"),
       await this.loadBuiltinTemplate("task", "generate-code.rdt.md"),
       await this.loadBuiltinTemplate("task", "generate-unit-test.rdt.md"),
@@ -58,6 +59,7 @@ export class ConversationTypesProvider {
     const result = await loadConversationFromFile(fileUri);
 
     if (result.type === "error") {
+      debugger;
       throw new Error(
         `Failed to load chat template '${fileUri.toString()}': ${result.error}`
       );

--- a/lib/extension/src/conversation/input/getOpenFiles.ts
+++ b/lib/extension/src/conversation/input/getOpenFiles.ts
@@ -1,0 +1,16 @@
+import * as vscode from "vscode";
+import { getActiveEditor } from "../../vscode/getActiveEditor";
+
+export const getOpenFiles = async () => {
+  const contextDocuments = vscode.workspace.textDocuments.filter(
+    (document) => document.uri.scheme === "file"
+  );
+
+  return contextDocuments.map((document) => {
+    return {
+      name: document.fileName,
+      language: document.languageId,
+      content: document.getText(),
+    };
+  });
+};

--- a/lib/extension/src/conversation/input/resolveVariable.ts
+++ b/lib/extension/src/conversation/input/resolveVariable.ts
@@ -5,6 +5,7 @@ import { Variable } from "../template/RubberduckTemplate";
 import { Message } from "../Message";
 import { getSelectedLocationText } from "./getSelectedLocationText";
 import { getSelectedTextWithDiagnostics } from "./getSelectionWithDiagnostics";
+import { getOpenFiles } from "./getOpenFiles";
 
 export async function resolveVariable(
   variable: Variable,
@@ -12,6 +13,8 @@ export async function resolveVariable(
 ): Promise<unknown> {
   const variableType = variable.type;
   switch (variableType) {
+    case "context":
+      return getOpenFiles();
     case "constant":
       return variable.value;
     case "message":

--- a/lib/extension/src/conversation/template/RubberduckTemplate.ts
+++ b/lib/extension/src/conversation/template/RubberduckTemplate.ts
@@ -71,6 +71,10 @@ const variableSchema = zod.discriminatedUnion("type", [
     property: zod.enum(["content"]),
   }),
   variableBaseSchema.extend({
+    type: zod.literal("context"),
+    time: zod.enum(["conversation-start"]),
+  }),
+  variableBaseSchema.extend({
     type: zod.literal("selected-text"),
     time: zod.enum(["conversation-start", "message"]),
   }),

--- a/template/task/explain-code-w-context.rdt.md
+++ b/template/task/explain-code-w-context.rdt.md
@@ -1,0 +1,134 @@
+# Explain Code
+
+Explain the selected code.
+
+## Template
+
+### Configuration
+
+```json conversation-template
+{
+  "id": "explain-code-with-context",
+  "engineVersion": 0,
+  "label": "Explain Code with Context",
+  "description": "Explain the selected code in context of all the open files.",
+  "tags": ["debug", "understand"],
+  "header": {
+    "title": "Explain Code ({{location}}) in context",
+    "icon": {
+      "type": "codicon",
+      "value": "book"
+    }
+  },
+  "variables": [
+    {
+      "name": "openFiles",
+      "time": "conversation-start",
+      "type": "context"
+    },
+    {
+      "name": "selectedText",
+      "time": "conversation-start",
+      "type": "selected-text",
+      "constraints": [{ "type": "text-length", "min": 1 }]
+    },
+    {
+      "name": "location",
+      "time": "conversation-start",
+      "type": "selected-location-text"
+    },
+    {
+      "name": "firstMessage",
+      "time": "message",
+      "type": "message",
+      "property": "content",
+      "index": 0
+    },
+    {
+      "name": "lastMessage",
+      "time": "message",
+      "type": "message",
+      "property": "content",
+      "index": -1
+    }
+  ],
+  "initialMessage": {
+    "placeholder": "Generating explanation",
+    "maxTokens": 2048
+  },
+  "response": {
+    "maxTokens": 2048,
+    "stop": ["Bot:", "Developer:"]
+  }
+}
+```
+
+### Initial Message Prompt
+
+```template-initial-message
+## Instructions
+Summarize the code below (emphasizing its key functionality) using the contents of the open files as context.
+
+## Selected Code
+\`\`\`{{language}}
+{{selectedText}}
+\`\`\`
+
+## Open Files
+{{#each openFiles}}
+### File: {{name}}
+\`\`\`{{language}}
+{{content}}
+\`\`\`
+{{/each}}
+
+## Task
+Summarize the code at a high level (including goal and purpose) with an emphasis on its key functionality. Use the contents of the open files as context.
+
+## Response
+
+```
+
+### Response Prompt
+
+```template-response
+## Instructions
+Continue the conversation below.
+Pay special attention to the current developer request.
+
+## Current Request
+Developer: {{lastMessage}}
+
+{{#if selectedText}}
+## Selected Code
+\`\`\`{{language}}
+{{selectedText}}
+\`\`\`
+{{/if}}
+
+## Code Summary
+{{firstMessage}}
+
+## Conversation
+{{#each messages}}
+{{#if (neq @index 0)}}
+{{#if (eq author "bot")}}
+Bot: {{content}}
+{{else}}
+Developer: {{content}}
+{{/if}}
+{{/if}}
+{{/each}}
+
+## Task
+Write a response that continues the conversation.
+Stay focused on current developer request.
+Consider the possibility that there might not be a solution.
+Ask for clarification if the message does not make sense or more input is needed.
+Use the style of a documentation article.
+Omit any links.
+Include code snippets (using Markdown) and examples where appropriate.
+
+## Response
+Bot:
+```


### PR DESCRIPTION
To quickly get the code working, I have added all open text files in the workspace to the context that is sent along with the explanation request to the API.

This likely has to be refined before it can be used. But I want to wait on feedback before doing that.

I was unable to run `pnpm test` successfully even on the main branch. But I did successfully get results from the api.

@all-contributors please add @restlessronin for code