### PR TITLE
Surface a way to extract the prompt text for use with OpenAI Plus web chat

### DIFF
--- a/app/vscode/asset/package.json
+++ b/app/vscode/asset/package.json
@@ -213,6 +213,12 @@
           "markdownDescription": "Specify the verbosity of logs that will appear in 'Rubberduck: Show Logs'.",
           "scope": "application"
         },
+        "rubberduck.openAI.surfacePromptForPlus": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable UI to surface the prompt text to use with OpenAI plus web chat",
+          "scope": "application"
+        },
         "rubberduck.openAI.baseUrl": {
           "type": "string",
           "default": "https://api.openai.com/v1/",

--- a/lib/common/src/webview-api/OutgoingMessage.ts
+++ b/lib/common/src/webview-api/OutgoingMessage.ts
@@ -52,6 +52,12 @@ export const outgoingMessageSchema = zod.discriminatedUnion("type", [
   zod.object({
     type: zod.literal("applyDiff"),
   }),
+  zod.object({
+    type: zod.literal("insertPromptIntoEditor"),
+    data: zod.object({
+      id: zod.string(),
+    }),
+  }),
 ]);
 
 /**

--- a/lib/common/src/webview-api/PanelState.ts
+++ b/lib/common/src/webview-api/PanelState.ts
@@ -9,6 +9,7 @@ export const panelStateSchema = zod
       conversations: zod.array(conversationSchema),
       selectedConversationId: zod.union([zod.string(), zod.undefined()]),
       hasOpenAIApiKey: zod.boolean(),
+      surfacePromptForOpenAIPlus: zod.boolean(),
       error: errorSchema.optional(),
     }),
     zod.object({

--- a/lib/extension/src/chat/ChatController.ts
+++ b/lib/extension/src/chat/ChatController.ts
@@ -109,6 +109,11 @@ export class ChatController {
           .getConversationById(message.data.id)
           ?.dismissError();
         break;
+      case "insertPromptIntoEditor":
+        await this.chatModel
+          .getConversationById(message.data.id)
+          ?.insertPromptIntoEditor();
+        break;
       case "applyDiff":
       case "reportError": {
         // Architecture debt: there are 2 views, but 1 outgoing message type

--- a/lib/extension/src/chat/ChatPanel.ts
+++ b/lib/extension/src/chat/ChatPanel.ts
@@ -4,6 +4,12 @@ import { ApiKeyManager } from "../ai/ApiKeyManager";
 import { WebviewContainer } from "../webview/WebviewContainer";
 import { ChatModel } from "./ChatModel";
 
+function getConfigSurfacePromptForOpenAIPlus(): boolean {
+  return vscode.workspace
+    .getConfiguration("rubberduck.openAI")
+    .get<boolean>("surfacePromptForPlus", false);
+}
+
 export class ChatPanel implements vscode.WebviewViewProvider {
   public static readonly id = "rubberduck.chat";
 
@@ -33,11 +39,13 @@ export class ChatPanel implements vscode.WebviewViewProvider {
     this.extensionUri = extensionUri;
     this.apiKeyManager = apiKeyManager;
 
+    const surfacePromptForOpenAIPlus = getConfigSurfacePromptForOpenAIPlus();
     this.state = {
       type: "chat",
       selectedConversationId: undefined,
       conversations: [],
       hasOpenAIApiKey,
+      surfacePromptForOpenAIPlus,
     };
 
     this.apiKeyManager.onUpdate(async () => {
@@ -98,12 +106,14 @@ export class ChatPanel implements vscode.WebviewViewProvider {
       conversations.push(await conversation.toWebviewConversation());
     }
 
+    const surfacePromptForOpenAIPlus = getConfigSurfacePromptForOpenAIPlus();
     const hasOpenAIApiKey = await this.apiKeyManager.hasOpenAIApiKey();
     this.state = {
       type: "chat",
       selectedConversationId: model.selectedConversationId,
       conversations,
       hasOpenAIApiKey,
+      surfacePromptForOpenAIPlus,
     };
     return this.renderPanel();
   }

--- a/lib/extension/src/conversation/Conversation.ts
+++ b/lib/extension/src/conversation/Conversation.ts
@@ -105,6 +105,20 @@ export class Conversation {
     return this.template.header.icon.value;
   }
 
+  async insertPromptIntoEditor(): Promise<void> {
+    const prompt =
+      this.messages[0] == null && this.template.initialMessage != null
+        ? this.template.initialMessage
+        : this.template.response;
+    const variables = await this.resolveVariablesAtMessageTime();
+    const text = await this.evaluateTemplate(prompt.template, variables);
+    const document = await vscode.workspace.openTextDocument({
+      language: "markdown",
+      content: text,
+    });
+    await vscode.window.showTextDocument(document);
+  }
+
   async exportMarkdown(): Promise<void> {
     const document = await vscode.workspace.openTextDocument({
       language: "markdown",

--- a/lib/webview/src/component/ConversationHeader.tsx
+++ b/lib/webview/src/component/ConversationHeader.tsx
@@ -1,15 +1,25 @@
 import { webviewApi } from "@rubberduck/common";
+import { on } from "events";
 import React from "react";
 
 export const ConversationHeader: React.FC<{
   conversation: webviewApi.Conversation;
-}> = ({ conversation }) => (
-  <div className="header">
-    <i className={`codicon codicon-${conversation.header.codicon} inline`} />
-    {conversation.header.isTitleMessage ? (
-      <span className="message user">{conversation.header.title}</span>
-    ) : (
-      conversation.header.title
-    )}
-  </div>
-);
+  onIconClick?: () => void;
+}> = ({ conversation, onIconClick }) => {
+  return (
+    <div className="header">
+      <i className={`codicon codicon-${conversation.header.codicon} inline`} />
+      {conversation.header.isTitleMessage ? (
+        <span className="message user">{conversation.header.title}</span>
+      ) : (
+        conversation.header.title
+      )}
+      {onIconClick && (
+        <span>
+          &nbsp;
+          < i className="codicon codicon-eye inline" onClick={onIconClick} />
+        </span>
+      )}
+    </div>
+  );
+};

--- a/lib/webview/src/component/ExpandedConversationView.tsx
+++ b/lib/webview/src/component/ExpandedConversationView.tsx
@@ -11,6 +11,7 @@ export const ExpandedConversationView: React.FC<{
   onClickRetry: () => void;
   onClickDelete: () => void;
   onClickExport: () => void;
+  onClickInsertPrompt: () => void;
 }> = ({
   conversation,
   onSendMessage,
@@ -18,55 +19,56 @@ export const ExpandedConversationView: React.FC<{
   onClickRetry,
   onClickDelete,
   onClickExport,
+  onClickInsertPrompt
 }) => {
-  const content = conversation.content;
+    const content = conversation.content;
 
-  return (
-    <div className={`conversation expanded`}>
-      <ConversationHeader conversation={conversation} />
+    return (
+      <div className={`conversation expanded`}>
+        <ConversationHeader conversation={conversation} onIconClick={onClickInsertPrompt} />
 
-      {(() => {
-        const type = content.type;
-        switch (type) {
-          case "messageExchange":
-            return (
-              <MessageExchangeView
-                content={content}
-                onSendMessage={onSendMessage}
-                onClickDismissError={onClickDismissError}
-                onClickRetry={onClickRetry}
-              />
-            );
-          case "instructionRefinement":
-            return (
-              <InstructionRefinementView
-                content={content}
-                onSendMessage={onSendMessage}
-                onClickDismissError={onClickDismissError}
-                onClickRetry={onClickRetry}
-              />
-            );
-          default: {
-            const exhaustiveCheck: never = type;
-            throw new Error(`unsupported type: ${exhaustiveCheck}`);
+        {(() => {
+          const type = content.type;
+          switch (type) {
+            case "messageExchange":
+              return (
+                <MessageExchangeView
+                  content={content}
+                  onSendMessage={onSendMessage}
+                  onClickDismissError={onClickDismissError}
+                  onClickRetry={onClickRetry}
+                />
+              );
+            case "instructionRefinement":
+              return (
+                <InstructionRefinementView
+                  content={content}
+                  onSendMessage={onSendMessage}
+                  onClickDismissError={onClickDismissError}
+                  onClickRetry={onClickRetry}
+                />
+              );
+            default: {
+              const exhaustiveCheck: never = type;
+              throw new Error(`unsupported type: ${exhaustiveCheck}`);
+            }
           }
-        }
-      })()}
+        })()}
 
-      <div className="footer">
-        <span className="action-panel">
-          <i
-            className="codicon codicon-save inline action-export"
-            title="Export conversation"
-            onClick={onClickExport}
-          />
-          <i
-            className="codicon codicon-trash inline action-delete"
-            title="Delete conversation"
-            onClick={onClickDelete}
-          />
-        </span>
+        <div className="footer">
+          <span className="action-panel">
+            <i
+              className="codicon codicon-save inline action-export"
+              title="Export conversation"
+              onClick={onClickExport}
+            />
+            <i
+              className="codicon codicon-trash inline action-delete"
+              title="Delete conversation"
+              onClick={onClickDelete}
+            />
+          </span>
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  };

--- a/lib/webview/src/component/ExpandedConversationView.tsx
+++ b/lib/webview/src/component/ExpandedConversationView.tsx
@@ -11,7 +11,7 @@ export const ExpandedConversationView: React.FC<{
   onClickRetry: () => void;
   onClickDelete: () => void;
   onClickExport: () => void;
-  onClickInsertPrompt: () => void;
+  onClickInsertPrompt?: () => void;
 }> = ({
   conversation,
   onSendMessage,
@@ -25,7 +25,11 @@ export const ExpandedConversationView: React.FC<{
 
     return (
       <div className={`conversation expanded`}>
-        <ConversationHeader conversation={conversation} onIconClick={onClickInsertPrompt} />
+        {
+          onClickInsertPrompt ?
+            (<ConversationHeader conversation={conversation} onIconClick={onClickInsertPrompt} />)
+            : (<ConversationHeader conversation={conversation} />)
+        }
 
         {(() => {
           const type = content.type;

--- a/lib/webview/src/panel/ChatPanelView.tsx
+++ b/lib/webview/src/panel/ChatPanelView.tsx
@@ -88,12 +88,12 @@ export const ChatPanelView: React.FC<{
                 data: { id: conversation.id },
               });
             }}
-            onClickInsertPrompt={() =>
+            onClickInsertPrompt={panelState.surfacePromptForOpenAIPlus ? () => {
               sendMessage({
                 type: "insertPromptIntoEditor",
                 data: { id: conversation.id },
               })
-            }
+            } : undefined}
           />
         ) : (
           <CollapsedConversationView

--- a/lib/webview/src/panel/ChatPanelView.tsx
+++ b/lib/webview/src/panel/ChatPanelView.tsx
@@ -88,6 +88,12 @@ export const ChatPanelView: React.FC<{
                 data: { id: conversation.id },
               });
             }}
+            onClickInsertPrompt={() =>
+              sendMessage({
+                type: "insertPromptIntoEditor",
+                data: { id: conversation.id },
+              })
+            }
           />
         ) : (
           <CollapsedConversationView

--- a/template/task/explain-code-w-context.rdt.md
+++ b/template/task/explain-code-w-context.rdt.md
@@ -38,13 +38,6 @@ Explain the selected code.
       "type": "selected-location-text"
     },
     {
-      "name": "firstMessage",
-      "time": "message",
-      "type": "message",
-      "property": "content",
-      "index": 0
-    },
-    {
       "name": "lastMessage",
       "time": "message",
       "type": "message",
@@ -52,41 +45,11 @@ Explain the selected code.
       "index": -1
     }
   ],
-  "initialMessage": {
-    "placeholder": "Generating explanation",
-    "maxTokens": 2048
-  },
   "response": {
     "maxTokens": 2048,
     "stop": ["Bot:", "Developer:"]
   }
 }
-```
-
-### Initial Message Prompt
-
-```template-initial-message
-## Instructions
-Summarize the code below (emphasizing its key functionality) using the contents of the open files as context.
-
-## Selected Code
-\`\`\`{{language}}
-{{selectedText}}
-\`\`\`
-
-## Open Files
-{{#each openFiles}}
-### File: {{name}}
-\`\`\`{{language}}
-{{content}}
-\`\`\`
-{{/each}}
-
-## Task
-Summarize the code at a high level (including goal and purpose) with an emphasis on its key functionality. Use the contents of the open files as context.
-
-## Response
-
 ```
 
 ### Response Prompt
@@ -107,7 +70,13 @@ Developer: {{lastMessage}}
 {{/if}}
 
 ## Code Summary
-{{firstMessage}}
+## Open Files
+{{#each openFiles}}
+### File: {{name}}
+\`\`\`{{language}}
+{{content}}
+\`\`\`
+{{/each}}
 
 ## Conversation
 {{#each messages}}


### PR DESCRIPTION
I have added a setting `rubberduck.openAI.surfacePromptForPlus` (default `false`) which enables a UI button on the Chat Title, to extract the prompt and insert it into a new text editor. The UI button (the `codicon-eye`) is only visible when the setting is true.

This enables us
1. easily experiment with prompts on the web UI
2. use the OpenAI plus webchat _instead_ of the API with a VS Code project. this may be what [this issue](https://github.com/rubberduck-ai/rubberduck-vscode/issues/61) is asking for. This becomes more useful as the context being passed becomes more intelligent, and the large context models are used.
