### PR TITLE
Add -0125- OpenAI models

### DIFF
--- a/app/vscode/asset/package.json
+++ b/app/vscode/asset/package.json
@@ -227,23 +227,29 @@
         },
         "rubberduck.model": {
           "type": "string",
-          "default": "gpt-3.5-turbo-1106",
+          "default": "gpt-3.5-turbo-0125",
           "enum": [
             "gpt-3.5-turbo",
             "gpt-3.5-turbo-16k",
             "gpt-3.5-turbo-1106",
+            "gpt-3.5-turbo-0125",
             "gpt-4",
             "gpt-4-32k",
             "gpt-4-1106-preview",
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
             "llama.cpp"
           ],
           "enumDescriptions": [
             "OpenAI GPT-3.5-turbo: 4k context window. Faster, less expensive model. Less accurate.",
             "OpenAI GPT-3.5-turbo: 16k context window. Faster, less expensive model. Less accurate.",
-            "OpenAI GPT-3.5-turbo: 16k context window. Latest 3.5 model. Faster, less expensive. Less accurate.",
+            "OpenAI GPT-3.5-turbo: 16k context window. Faster, less expensive. Less accurate.",
+            "OpenAI GPT-3.5-turbo: 16k context window. Faster, less expensive. Less accurate. The latest GPT-3.5 Turbo model with higher accuracy at responding in requested formats and a fix for a bug which caused a text encoding issue for non-English language function calls. Returns a maximum of 4,096 output tokens.",
             "OpenAI GPT-4: 8k context window. Expensive, slow model. More accurate.",
             "OpenAI GPT-4: 32k context window. Expensive, slow model. More accurate.",
-            "OpenAI GPT-4: 128k context window. Latest model. Expensive (but cheaper than 32k), slow model. More accurate.",
+            "OpenAI GPT-4 Turbo: 128k context window. Expensive (but cheaper than 32k), slow model. More accurate.",
+            "OpenAI GPT-4 Turbo: 128k context window. Expensive (but cheaper than 32k), slow model. More accurate. The latest GPT-4 model intended to reduce cases of \"laziness\" where the model doesn't complete a task.",
+            "OpenAI GPT-4 Turbo: Currently points to gpt-4-0125-preview.",
             "(Experimental) Llama.cpp: Calls Llama.cpp running locally on http://127.0.0.1:8080. Use for local models with Llama 2 prompt format."
           ],
           "markdownDescription": "Select the OpenAI model that you want to use.",

--- a/lib/extension/src/ai/AIClient.ts
+++ b/lib/extension/src/ai/AIClient.ts
@@ -29,6 +29,7 @@ function getModel() {
       "gpt-4-32k",
       "gpt-4-1106-preview",
       "gpt-4-0125-preview",
+      "gpt-4-turbo-preview",
       "gpt-3.5-turbo",
       "gpt-3.5-turbo-16k",
       "gpt-3.5-turbo-1106",


### PR DESCRIPTION
Add `-0125-` OpenAI models to the configuration.

Similar to https://github.com/rubberduck-ai/rubberduck-vscode/pull/110

The models were "partially" added here https://github.com/rubberduck-ai/rubberduck-vscode/commit/67864041904b43ff989d2b45d58e3d5fb5459e5a

I've taken the descriptions from https://platform.openai.com/docs/models/gpt-3-5-turbo and https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo

Let me know if that looks OK.

### Basic test

<img width="1136" alt="Screenshot 2024-02-02 at 22 36 15" src="https://github.com/rubberduck-ai/rubberduck-vscode/assets/166651/d014580a-0746-40bd-90dc-7c3f4a8acf23">

<img width="1136" alt="Screenshot 2024-02-02 at 22 37 30" src="https://github.com/rubberduck-ai/rubberduck-vscode/assets/166651/8bfc1c4c-ce4c-48d7-ab55-dbff25fb517a">


